### PR TITLE
Add the proposed setting to make HTTP links always be opened in the browser

### DIFF
--- a/open_include.py
+++ b/open_include.py
@@ -143,7 +143,7 @@ class OpenInclude(sublime_plugin.TextCommand):
 	# try opening the resouce
 	def try_open(self, window, maybe_path):
 		if maybe_path[:4] == 'http':
-			if BINARY.search(maybe_path):
+			if BINARY.search(maybe_path) or self.view.settings().get("open_http_include_in_browser", False):
 				try:
 					sublime.status_message("Opening in browser " + maybe_path)
 					import webbrowser
@@ -155,10 +155,7 @@ class OpenInclude(sublime_plugin.TextCommand):
 				sublime.status_message("Opening URL " + maybe_path)
 				thread.start_new_thread(self.read_url, (maybe_path, maybe_path))
 				return True
-				# sublime.status_message("Opening in browser " + maybe_path)
-				# import webbrowser
-				# webbrowser.open_new_tab(maybe_path)
-				# return True
+
 		if os.path.isfile(maybe_path):
 			if BINARY.search(maybe_path):
 				import sys

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Description
 This plugin will try to open Sublime Text file paths found on selections/cursor when pressing "ALT+D".
 It has support for .coffee/.js/.hbs/.jade files when no extension specified. Usefull when doing require style javascript modules.
 
-strings starting with HTTP will open with default browser (if binary), if not, we will read the file with urllib and open the result in a new view.
+Strings starting with HTTP will open with default browser (if binary), if not, we will read the file with urllib and open the result in a new view. By setting the `"open_http_include_in_browser"` setting in your user preferences to `true`, we will always open the default browser.
 
 Sources:
 ------------------


### PR DESCRIPTION
Yeah, I really like this a lot when I make notes and add links to my "txt" files.
Additionally, the setting is also affected by syntax- or project-specific settings.
