### PR TITLE
More support for partials

### DIFF
--- a/open_include.py
+++ b/open_include.py
@@ -79,7 +79,7 @@ class OpenInclude(sublime_plugin.TextCommand):
 			if path.strip() == '':
 				continue
 
-			extensions = ["", ".coffee", ".hbs", ".jade", ".js", ".scss"];
+			extensions = ["", ".coffee", ".hbs", ".jade", ".js", ".scss", ".sass", ".styl", ".less"];
 			for extension in extensions:
 				# remove quotes
 				path = re.sub('^"|\'', '',  re.sub('"|\'$', '', path.strip()))


### PR DESCRIPTION
Sass supports extensionless `@import`s for `.sass` extension too. Also, Less and Stylus preprocessors also support that way of importing, so I've added those extensions too.
