### PR TITLE
Add expand_tilde option

### DIFF
--- a/Open-Include.sublime-settings
+++ b/Open-Include.sublime-settings
@@ -16,6 +16,10 @@
 	// splits the view, and open the file in a secondary column
 	"in_secondary_colum": false,
 
+	// Expand tilde characters in the path to the user's home directory, i.e.:
+	// ~/Project/file_name -> /home/user_id/Project/file_name
+	"expand_tilde": true,
+
 	// Additionally check for these combinations of extension and prefix when
 	// searching for a file
 	"auto_extension": [

--- a/open_include.py
+++ b/open_include.py
@@ -7,6 +7,8 @@ import time
 import sublime
 import sublime_plugin
 
+from os.path import expanduser
+
 try:
     from .Edit import Edit as Edit
 except:
@@ -315,6 +317,10 @@ class OpenIncludeThread(threading.Thread):
                 paths += '\n' + path.replace('./', '.').replace('.', '/')
                 # replace :: for /
                 paths += '\n' + path.replace('::', '/')
+                if s.get('expand_tilde'):
+                  # replace ~ for the user's home directory
+                  user_home_path = expanduser("~")
+                  paths += '\n' + path.replace('~', user_home_path)
 
         paths = paths.strip().split('\n')
 


### PR DESCRIPTION
This option automatically translates tilde characters to the currently
logged in user home directory, i.e.: ~/Project/file_name ->
/home/Project/file_name.

This has currently only been tested under my Mac OS X Yosemite v10.10.1
environment, but in theory, should also work under Linux and Windows 
environments, too. Testing is welcome! :-)