### PR TITLE
[Question] Open preprocessors files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Description
 
 This plugin will try to open Sublime Text file paths found on caret positions or partial selections when pressing <kbd>ALT+D</kbd>.
-It has support for custom prefixes and subfixes. Usefull when doing require style JavaScript modules when no extension specified.
+It has support for custom prefixes and subfixes. Useful when doing require style JavaScript modules when no extension specified.
 
 Strings starting with HTTP will open with default browser (if binary, ie ends with png), if not, we will read the file with urllib and open the result in a new view/tab. By setting the `"open_http_in_browser"` setting in your user preferences to `true`, we will always open the default browser.
 


### PR DESCRIPTION
### 1. Briefly

I don't find, how I can open preprocessors files:

    1. if I run command `open_include`,
    2. and if my carriage in path to css file.

### 2. Argumentation

I preview my HTML page in browser → I'm don't glad results → I want to edit my `.styl` files. At the moment I don't find, how I can quick one-press open `.styl` file, that I want to edit.

### 3. Settings

I use Stylus preprocessor. My `.styl` file from `stylus` folder compile to `.css` file of `css` folder.

For example, part of my project structure:

```python
stylus
    folder1
        file1.styl
    folder2
        file2.styl

css
    folder1
        file1.css
    folder2
        file2.css
```

Part of my `KristinaWinner.html` file:

```html
<link rel="stylesheet" href="../css/folder1/file1.css">
<link rel="stylesheet" href="../css/folder2/file2.css">
```

### 4. Steps to reproduce

I open `KristinaWinner.html` file in Sublime Text → I place my carriage between double quotes in `"../css/folder1/file1.css"` text → I run command `open_include`.

### 5. Actual behavior

`file1.css` open for me.

### 6. Expected behavior

`file1.css` and `file1.styl` open for me.

### 7. Did not help

1. include preprocessors files in HTML [**impossible**](http://stackoverflow.com/q/15063834/5951529) at the moment,
1. googling,
1. I try change Open Include [**settings**](https://github.com/titoBouzout/Open-Include/blob/master/Open-Include.sublime-settings), but I can't get expected behavior.

Thanks.