### PR TITLE
Fixes wrong paths

### DIFF
--- a/open_include.py
+++ b/open_include.py
@@ -319,12 +319,11 @@ class OpenIncludeThread(threading.Thread):
                 pass
 
         user_home_path = expanduser("~")
-
-        for path in paths.split('\n'):
+        
+	paths = re.sub('"|\'|<|>|\(|\)|\{|\}|\[|\]|;', '', paths)
+        
+	for path in paths.split('\n'):
             if not path.startswith('http'):
-
-                paths += re.sub('"|\'|<|>|\(|\)|\{|\}|\[|\]|;', '', path)
-
                 # remove quotes
                 paths += '\n' + re.sub(';', '', path)
                 # remove :row:col


### PR DESCRIPTION
For some reasons, that regex broke the SCSS includes. It was marked as a regression fix on 1a17a9b7ebb1e3b0084b8762a2998b85765faa26 but... i'm not sure what it fixes there :)

The problem I suspect is that it is augmenting the path like this (see the quotes on the marked line):

```
[
"'pages/article'", 
"'pages/article'pages/article",  <<<<<<<<<<<<<<<<
...]
```

And later on the parser has trouble with that.

PS: while the opening existing files didn't worked, the creation of new files did.