### PR TITLE
Fix Open URLs in browser

### DIFF
--- a/open_include.py
+++ b/open_include.py
@@ -426,7 +426,7 @@ class OpenIncludeThread(threading.Thread):
 
         if maybe_path.startswith('http'):
             # HTTP URL
-            if BINARY.search(maybe_path) or s.get("open_http_in_browser", False):
+            if BINARY.search(maybe_path) or get_setting("open_http_in_browser", False):
                 sublime.status_message("Opening in Browser " + maybe_path)
 
                 import webbrowser


### PR DESCRIPTION
6dcbabc missed to replace one occurrence of `s.get` so that it crashes if you try to open a URL in the browser.